### PR TITLE
fix japanese translation

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,7 +67,7 @@
     <string name="Type_Something_Here">入力してみてください</string>
     <string name="Legacy_file_picker">Legacy file picker</string>
     <string name="Use_legacy_file_picker">Use legacy file picker</string>
-    <string name="action_edit">コマンド</string>
+    <string name="action_edit">編集</string>
     <string name="action_undo">やり直し</string>
     <string name="action_redo">やり直しのやり直し</string>
 </resources>


### PR DESCRIPTION
I translated it as コマンド (Command) because it is a special group of actions. This word is commonly translated as 編集 (Edit), so please approve this one.