### PR TITLE
Highlight color resolved

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -11,6 +11,7 @@
 		android:id="@+id/editText1"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
+		android:textCursorDrawable="@null"
 		android:padding="5dip"
 		android:hint="@string/Type_Something_Here"
 		android:fadingEdge="none"


### PR DESCRIPTION
Hi @maxistar,   I added  <android:textCursorDrawable="@null"> which means that "cursor's color"  will be the same as the "font color" . That will prevent having incompatible "background" and "highlight" color . I which you merge my PR 😉  