### PR TITLE
Add two-finger pan to move the text in all directions

### DIFF
--- a/app/src/main/java/com/maxistar/textpad/activities/EditorActivity.java
+++ b/app/src/main/java/com/maxistar/textpad/activities/EditorActivity.java
@@ -38,10 +38,12 @@ import android.print.PrintJob;
 import android.print.PrintManager;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.Layout;
 import android.text.Spanned;
 import android.text.TextWatcher;
 import android.text.style.BackgroundColorSpan;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.WindowInsets;
@@ -214,6 +216,7 @@ public class EditorActivity extends AppCompatActivity {
         }
         mText = this.findViewById(R.id.editText1);
         mText.setBackgroundResource(android.R.color.transparent);
+        mText.setOnTouchListener(new TwoFingerPanTouchListener());
         if (!settingsService.isAutoWrapping()) {
             disableEditorAutowrapping();
         }
@@ -1958,6 +1961,105 @@ public class EditorActivity extends AppCompatActivity {
         int duration = Toast.LENGTH_SHORT;
         Toast toast = Toast.makeText(context, toast_str, duration);
         toast.show();
+    }
+
+    // TwoFingerPanTouchListener
+    private class TwoFingerPanTouchListener implements View.OnTouchListener {
+
+        private boolean panningActive = false;
+        private float lastFocalX;
+        private float lastFocalY;
+
+        @Override
+        public boolean onTouch(View view, MotionEvent event) {
+            switch (event.getActionMasked()) {
+                case MotionEvent.ACTION_DOWN:
+                    panningActive = false;
+                    return false;
+                case MotionEvent.ACTION_POINTER_DOWN:
+                    if (event.getPointerCount() == 2) {
+                        panningActive = true;
+                        view.getParent().requestDisallowInterceptTouchEvent(true);
+                        lastFocalX = focalX(event);
+                        lastFocalY = focalY(event);
+                    }
+                    return panningActive;
+                case MotionEvent.ACTION_MOVE:
+                    if (!panningActive) {
+                        return false;
+                    }
+                    float focalX = focalX(event);
+                    float focalY = focalY(event);
+                    panContent(
+                            Math.round(focalX - lastFocalX),
+                            Math.round(focalY - lastFocalY)
+                    );
+                    lastFocalX = focalX;
+                    lastFocalY = focalY;
+                    return true;
+                case MotionEvent.ACTION_POINTER_UP:
+                    if (panningActive) {
+                        view.getParent().requestDisallowInterceptTouchEvent(false);
+                    }
+                    return panningActive;
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    boolean wasPanning = panningActive;
+                    panningActive = false;
+                    view.getParent().requestDisallowInterceptTouchEvent(false);
+                    return wasPanning;
+                default:
+                    return panningActive;
+            }
+        }
+
+        private float focalX(MotionEvent event) {
+            float sum = 0;
+            for (int i = 0; i < event.getPointerCount(); i++) {
+                sum += event.getX(i);
+            }
+            return sum / event.getPointerCount();
+        }
+
+        private float focalY(MotionEvent event) {
+            float sum = 0;
+            for (int i = 0; i < event.getPointerCount(); i++) {
+                sum += event.getY(i);
+            }
+            return sum / event.getPointerCount();
+        }
+    }
+
+    private void panContent(int deltaX, int deltaY) {
+        Layout layout = mText.getLayout();
+        int maxX = layout == null ? 0 :
+                layout.getWidth() + mText.getTotalPaddingLeft() + mText.getTotalPaddingRight()
+                        - mText.getWidth();
+        int newX = clampScroll(mText.getScrollX() - deltaX, maxX);
+
+        if (simpleScrolling()) {
+            int maxY = layout == null ? 0 :
+                    layout.getHeight() + mText.getTotalPaddingTop() + mText.getTotalPaddingBottom()
+                            - mText.getHeight();
+            int newY = clampScroll(mText.getScrollY() - deltaY, maxY);
+            mText.scrollTo(newX, newY);
+            return;
+        }
+
+        if (scrollView != null) {
+            scrollView.scrollBy(0, -deltaY);
+        }
+        mText.scrollTo(newX, mText.getScrollY());
+    }
+
+    private int clampScroll(int value, int max) {
+        if (value < 0) {
+            return 0;
+        }
+        if (max > 0 && value > max) {
+            return max;
+        }
+        return value;
     }
 
     // QueryTextListener


### PR DESCRIPTION
## Summary

Adds a two-finger pan gesture: while two fingers are pressed on the text, dragging moves the text in any direction (left/right/up/down).

## How it works

- New `TwoFingerPanTouchListener` attached to the editor `EditText` in `EditorActivity`.
- When a second pointer goes down, the listener takes over the gesture and scrolls the content to follow the fingers (focal point of the two pointers).
- Works in both layouts:
  - default (`ScrollView`) — vertical scroll via the `ScrollView`, horizontal via the `EditText`;
  - "simple scrolling" — both axes via the `EditText`.
- Scrolling is clamped to the content bounds (`panContent`/`clampScroll`) so the text cannot be panned past its edges.
- Single-finger behavior (cursor placement, selection, drag scrolling) is untouched.

Note: horizontal panning only applies when text is wider than the screen, i.e. when auto-wrap is turned off.

## Verification

- `./gradlew compileDebugJavaWithJavac` — OK
- `./gradlew testDebugUnitTest` — OK
- `./gradlew lint` — no errors

## Video

https://youtube.com/shorts/mreTjptc4fY