### PR TITLE
Add "Go To" menu option for moving cursor to beginning or end

### DIFF
--- a/app/src/main/java/com/maxistar/textpad/activities/EditorActivity.java
+++ b/app/src/main/java/com/maxistar/textpad/activities/EditorActivity.java
@@ -993,6 +993,8 @@ public class EditorActivity extends AppCompatActivity {
             saveFile();
         } else if (itemId == R.id.menu_document_save_as) {
             saveAs();
+        } else if (itemId == R.id.menu_document_go_to) {
+            moveCaretPosition();
         } else if (itemId == R.id.menu_edit_undo) {
             editUndo();
         } else if (itemId == R.id.menu_edit_redo) {
@@ -2071,6 +2073,23 @@ public class EditorActivity extends AppCompatActivity {
             mText.requestFocus();
             queryTextListener = null;
             return true;
+        }
+    }
+
+    private void moveCaretPosition() {
+        if (mText.length() != 0) {
+            new AlertDialog.Builder(this)
+                .setIcon(android.R.drawable.ic_menu_directions)
+                .setTitle(R.string.Go_To_Title)
+                .setMessage(R.string.Go_To_Description)
+                .setPositiveButton(R.string.Go_To_End,
+                        (dialog, which) -> {
+                            mText.setSelection(mText.length());
+                        })
+                .setNegativeButton(R.string.Go_To_Beginning,
+                        (dialog, which) -> {
+                            mText.setSelection(0);
+                        }).show();
         }
     }
 }

--- a/app/src/main/res/drawable-anydpi/ic_arrow_forward.xml
+++ b/app/src/main/res/drawable-anydpi/ic_arrow_forward.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="#454545"
+      android:pathData="M12,4l-1.41,1.41L16.17,11H4v2h12.17l-5.58,5.59L12,20l8,-8z"/>
+</vector>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -86,6 +86,11 @@
         android:icon="@drawable/ic_save_as"
         app:iconTint="@color/colorIcon" />
     <item
+        android:id="@+id/menu_document_go_to"
+        android:title="@string/Go_To"
+        android:icon="@drawable/ic_arrow_forward"
+        app:iconTint="@color/colorIcon" />
+    <item
         android:id="@+id/menu_document_share"
         android:title="@string/Menu_Share"
         android:icon="@drawable/ic_share"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">جديد</string>
     <string name="Save">حفظ</string>
     <string name="Save_As">حفظ كـ</string>
+    <string name="Go_To">الانتقال إلى</string>
+    <string name="Go_To_Title">الانتقال إلى الموضع</string>
+    <string name="Go_To_Description">إلى أين تريد نقل المؤشر؟</string>
+    <string name="Go_To_Beginning">البداية</string>
+    <string name="Go_To_End">النهاية</string>
     <string name="Location">الموقع: %s</string>
     <string name="Select">تحديد</string>
     <string name="File_Name">إسم الملف:</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">Neu</string>
     <string name="Save">Speichern</string>
     <string name="Save_As">Speichern unter</string>
+    <string name="Go_To">Gehe zu</string>
+    <string name="Go_To_Title">Zu Position gehen</string>
+    <string name="Go_To_Description">Wohin möchten Sie den Cursor bewegen?</string>
+    <string name="Go_To_Beginning">Anfang</string>
+    <string name="Go_To_End">Ende</string>
     <string name="Location">Lage: %s</string>
     <string name="Select">Wählen</string>
     <string name="File_Name">Dateiname:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">Nuevo</string>
     <string name="Save">Guardar</string>
     <string name="Save_As">Guardar como</string>
+    <string name="Go_To">Ir a</string>
+    <string name="Go_To_Title">Ir a la posición</string>
+    <string name="Go_To_Description">¿Dónde quieres mover el cursor?</string>
+    <string name="Go_To_Beginning">Principio</string>
+    <string name="Go_To_End">Final</string>
     <string name="Location">Ubicación: %s</string>
     <string name="Select">Seleccionar</string>
     <string name="File_Name">Nombre del archivo:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -5,6 +5,11 @@
     <string name="New">Nouveau</string>
     <string name="Save">Enregistrer</string>
     <string name="Save_As">Enregistrer sous</string>
+    <string name="Go_To">Aller à</string>
+    <string name="Go_To_Title">Aller à la position</string>
+    <string name="Go_To_Description">Où souhaitez-vous déplacer le curseur ?</string>
+    <string name="Go_To_Beginning">Début</string>
+    <string name="Go_To_End">Fin</string>
     <string name="Location">Emplacement : %s</string>
     <string name="Select">Sélectionner</string>
     <string name="File_Name">Nom du fichier</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- credits: https://github.com/akarshit-1609 -->
     <string name="app_name">Simple Text Editor</string>
     <string name="app_name_settings">Simple Text Editor - सेटिंग्स</string>
     <string name="Open">खोलें</string>
@@ -7,6 +8,11 @@
     <string name="New">नया</string>
     <string name="Save">सहेजें</string>
     <string name="Save_As">इस रूप में सहेजें</string>
+    <string name="Go_To">पर जाएँ</string>
+    <string name="Go_To_Title">स्थिति पर जाएँ</string>
+    <string name="Go_To_Description">आप कर्सर को कहाँ ले जाना चाहते हैं?</string>
+    <string name="Go_To_Beginning">शुरुआत</string>
+    <string name="Go_To_End">अंत</string>
     <string name="Location">स्थान: %s</string>
     <string name="Select">चुनें</string>
     <string name="File_Name">फ़ाइल का नाम:</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">Nuovo</string>
     <string name="Save">Salva</string>
     <string name="Save_As">Salva come</string>
+    <string name="Go_To">Vai a</string>
+    <string name="Go_To_Title">Vai alla posizione</string>
+    <string name="Go_To_Description">Dove vuoi spostare il cursore?</string>
+    <string name="Go_To_Beginning">Inizio</string>
+    <string name="Go_To_End">Fine</string>
     <string name="Location">Posizione: %s</string>
     <string name="Select">Seleziona</string>
     <string name="File_Name">Nome del file:</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -7,6 +7,11 @@
     <string name="New">新規作成</string>
     <string name="Save">上書き保存</string>
     <string name="Save_As">別名で保存</string>
+    <string name="Go_To">移動</string>
+    <string name="Go_To_Title">位置に移動</string>
+    <string name="Go_To_Description">カーソルをどこに移動しますか？</string>
+    <string name="Go_To_Beginning">先頭</string>
+    <string name="Go_To_End">末尾</string>
     <string name="Location">パス: %s</string>
     <string name="Select">改行コードを選択</string>
     <string name="File_Name">ファイル名:</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -7,6 +7,11 @@
     <string name="New">Nowy</string>
     <string name="Save">Zapisz</string>
     <string name="Save_As">Zapisz jako</string>
+    <string name="Go_To">Przejdź do</string>
+    <string name="Go_To_Title">Przejdź do pozycji</string>
+    <string name="Go_To_Description">Gdzie chcesz przenieść kursor?</string>
+    <string name="Go_To_Beginning">Początek</string>
+    <string name="Go_To_End">Koniec</string>
     <string name="Location">Lokalizacja: %s</string>
     <string name="Select">Wybierz</string>
     <string name="File_Name">Nazwa pliku:</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">Novo</string>
     <string name="Save">Salvar</string>
     <string name="Save_As">Salvar como</string>
+    <string name="Go_To">Ir para</string>
+    <string name="Go_To_Title">Ir para a posição</string>
+    <string name="Go_To_Description">Para onde você deseja mover o cursor?</string>
+    <string name="Go_To_Beginning">Início</string>
+    <string name="Go_To_End">Fim</string>
     <string name="Location">Local: %s</string>
     <string name="Select">Selecionar</string>
     <string name="File_Name">Nome do arquivo:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">Новый</string>
     <string name="Save">Сохранить</string>
     <string name="Save_As">Сохранить Как</string>
+    <string name="Go_To">Перейти</string>
+    <string name="Go_To_Title">Перейти к позиции</string>
+    <string name="Go_To_Description">Куда вы хотите переместить курсор?</string>
+    <string name="Go_To_Beginning">Начало</string>
+    <string name="Go_To_End">Конец</string>
     <string name="Location">Путь: %s</string>
     <string name="Select">Выбрать</string>
     <string name="File_Name">Имя файла:</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -6,6 +6,11 @@
     <string name="New">Yeni Dosya</string>
     <string name="Save">Kaydet</string>
     <string name="Save_As">Farklı Kaydet</string>
+    <string name="Go_To">Git</string>
+    <string name="Go_To_Title">Konuma Git</string>
+    <string name="Go_To_Description">mleci nereye taşımak istiyorsunuz?</string>
+    <string name="Go_To_Beginning">Başlangıç</string>
+    <string name="Go_To_End">Son</string>
     <string name="Location">Yer: %s</string>
     <string name="Select">Seç</string>
     <string name="File_Name">Dosya Adı:</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -7,6 +7,11 @@
     <string name="New">Новий</string>
     <string name="Save">Зберегти</string>
     <string name="Save_As">Зберегти як</string>
+    <string name="Go_To">Перейти</string>
+    <string name="Go_To_Title">Перейти до позиції</string>
+    <string name="Go_To_Description">Куди ви хочете перемістити курсор?</string>
+    <string name="Go_To_Beginning">Початок</string>
+    <string name="Go_To_End">Кінець</string>
     <string name="Location">Розташування: %s</string>
     <string name="Select">Обрати</string>
     <string name="File_Name">Назва файлу:</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -8,6 +8,11 @@
     <string name="New">新建</string>
     <string name="Save">保存</string>
     <string name="Save_As">另存为</string>
+    <string name="Go_To">转到</string>
+    <string name="Go_To_Title">转到位置</string>
+    <string name="Go_To_Description">您要将光标移动到哪里？</string>
+    <string name="Go_To_Beginning">开头</string>
+    <string name="Go_To_End">结尾</string>
     <string name="Location">位置: %s</string>
     <string name="Select">选择</string>
     <string name="File_Name">文件名:</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -7,6 +7,11 @@
     <string name="New">開啟新檔</string>
     <string name="Save">儲存</string>
     <string name="Save_As">另存新檔</string>
+    <string name="Go_To">前往</string>
+    <string name="Go_To_Title">前往位置</string>
+    <string name="Go_To_Description">您要將游標移動到哪裡？</string>
+    <string name="Go_To_Beginning">開頭</string>
+    <string name="Go_To_End">結尾</string>
     <string name="Location">位置：%s</string>
     <string name="Select">選擇</string>
     <string name="File_Name">檔案名稱：</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -8,6 +8,11 @@
     <string name="New">新建</string>
     <string name="Save">保存</string>
     <string name="Save_As">另存为</string>
+    <string name="Go_To">转到</string>
+    <string name="Go_To_Title">转到位置</string>
+    <string name="Go_To_Description">您要将光标移动到哪里？</string>
+    <string name="Go_To_Beginning">开头</string>
+    <string name="Go_To_End">结尾</string>
     <string name="Location">位置: %s</string>
     <string name="Select">选择</string>
     <string name="File_Name">文件名:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,11 @@
     <string name="New">New</string>
     <string name="Save">Save</string>
     <string name="Save_As">Save As</string>
+    <string name="Go_To">Go To</string>
+    <string name="Go_To_Title">Go to Position</string>
+    <string name="Go_To_Description">Where would you like to move the cursor?</string>
+    <string name="Go_To_Beginning">Beginning</string>
+    <string name="Go_To_End">End</string>
     <string name="Location">Location: %s</string>
     <string name="Select">Select</string>
     <string name="File_Name">File Name:</string>


### PR DESCRIPTION
### Summary

Added a "Go To" feature to the simple text editor menu that allows users to quickly move the text cursor/caret to the beginning or end of the currently opened file. This is particularly useful when working with large documents, where manually scrolling to the beginning or end can be time-consuming and inefficient.

### Changes

* Added **"Go To"** option to the editor menu.
* Added a dialog with two actions:

  * **Beginning** — moves the cursor to the start of the opened text file.
  * **End** — moves the cursor to the end of the opened text file.
* The feature works with the currently opened document.

### User Flow

1. Open a text file.
2. Select **Go To** from the menu.
3. Choose **Beginning** or **End**.
4. The cursor moves to the corresponding position in the document.